### PR TITLE
Fix fill factor, error tightening and growing ratio. 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,8 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ahash = "0.7"
-serde = { version = "1.0.125" }
+seahash = "4.1"
+serde = "1.0.125"
 serde_bytes = "0.11"
 serde_derive = "1.0.125"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,10 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-seahash = "4.1"
 serde = "1.0.125"
 serde_bytes = "0.11"
 serde_derive = "1.0.125"
+xxhash-rust = {version = "0.8.2", features = ["xxh3"]}
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "growable-bloom-filter"
-version = "1.0.3"
-authors = ["David Briggs <david@dpbriggs.ca>"]
+version = "2.0.0"
+authors = ["David Briggs <david@dpbriggs.ca>", "Arthur Silva <arthurprs@gmail.com>"]
 edition = "2018"
 license = "MIT"
 description = "Scalable Bloom Filters with serde support"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,8 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bitvec = {version="0.17.4", features=["serde"]}
 serde = { version = "1.0.101", features = ["alloc"] } # damn it feels good be a gangster
+serde_bytes = "0.11"
 seahash = "3.0.6"
 serde_derive = "1.0.101"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,10 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-serde = { version = "1.0.101", features = ["alloc"] } # damn it feels good be a gangster
+ahash = "0.7"
+serde = { version = "1.0.125" }
 serde_bytes = "0.11"
-seahash = "3.0.6"
-serde_derive = "1.0.101"
+serde_derive = "1.0.125"
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/README.md
+++ b/README.md
@@ -53,4 +53,4 @@ you could use GrowableBloom to figure out which ones do NOT have XYZ.
 The (de)serialized bloom filter can be transferred and used across different
 platforms, idependent of endianess, architecture and word size.
 
-Note that stability is only guaranteed within the same major version.
+Note that stability is only guaranteed within the same major version of the crate.

--- a/README.md
+++ b/README.md
@@ -48,3 +48,9 @@ Bloom filters are typically used as a pre-cache to avoid expensive operations.
 For example, if you need to ask ten thousand servers if they have data XYZ,
 you could use GrowableBloom to figure out which ones do NOT have XYZ.
 
+## Stability
+
+The (de)serialized bloom filter can be transferred and used across different
+platforms, idependent of endianess, architecture and word size.
+
+Note that stability is only guaranteed within the same major version.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -306,6 +306,16 @@ impl GrowableBloom {
         self.blooms.is_empty()
     }
 
+    /// The current estimated number of elements added to the filter.
+    pub fn len(&self) -> usize {
+        self.inserts
+    }
+
+    /// The current estimated capacity of the filter.
+    pub fn capacity(&self) -> usize {
+        self.capacity
+    }
+
     /// Record if `item` already exists in the filter, and insert it if it doesn't already exist.
     ///
     /// Returns `true` if the item already existed in the filter.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,6 @@
 #[cfg(feature = "nightly")]
 extern crate test;
 
-use seahash::SeaHasher;
 use serde_derive::{Deserialize, Serialize};
 use std::{
     hash::{Hash, Hasher},
@@ -125,20 +124,16 @@ impl Bloom {
 
 /// Returns 2 hashes for the given item
 fn double_hashing_hashes<T: Hash>(item: T) -> (usize, usize) {
-    let mut hs = SeaHasher::with_seeds(
-        0xe7b0c93ca8525013,
-        0x011d02b854ae8182,
-        0x7bcc5cf9c39cec76,
-        0xfa336285d102d083,
+    let mut hs = ahash::AHasher::new_with_keys(
+        0xe7b0c93ca8525013011d02b854ae8182,
+        0x7bcc5cf9c39cec76fa336285d102d083,
     );
     item.hash(&mut hs);
     let h1 = hs.finish();
 
-    hs = SeaHasher::with_seeds(
-        0x16f11fe89b0d677c,
-        0xb480a793d8e6c86c,
-        0x6fe2e5aaf078ebc9,
-        0x14f994a4c5259381,
+    hs = ahash::AHasher::new_with_keys(
+        0x16f11fe89b0d677cb480a793d8e6c86c,
+        0x6fe2e5aaf078ebc914f994a4c5259381,
     );
     item.hash(&mut hs);
 
@@ -508,6 +503,12 @@ mod growable_bloom_tests {
         fn bench_many(b: &mut Bencher) {
             let mut gbloom = GrowableBloom::new(0.05, 100000);
             b.iter(|| gbloom.insert(10));
+        }
+        #[bench]
+        fn bench_insert_string(b: &mut Bencher) {
+            let s: String = (0..100).map(|_| 'X').collect();
+            let mut gbloom = GrowableBloom::new(0.05, 100000);
+            b.iter(|| gbloom.insert(&s))
         }
         #[bench]
         fn bench_insert_large(b: &mut Bencher) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@ impl Bloom {
         // n ≈ −m ln(1−p)  (slice_len_bits)
         // M = k * m       (total_bits)
         // for optimal filter p = 0.5, which gives:
-        // n ≈ −m ln(0.5), rearranging: m = -n / ln(0.5), rearranging: m = n / log 2
+        // n ≈ −m ln(0.5), rearranging: m = -n / ln(0.5) = n / ln(2)
         debug_assert!(capacity >= 1);
         debug_assert!(0.0 < error_ratio && error_ratio < 1.0);
         // We're using ceil instead of round in order to get an error rate <= the desired.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -615,46 +615,46 @@ mod growable_bloom_tests {
         use test::Bencher;
         #[bench]
         fn bench_new(b: &mut Bencher) {
-            b.iter(|| GrowableBloom::new(0.05, 1000));
+            b.iter(|| GrowableBloom::new(0.01, 1000));
         }
         #[bench]
         fn bench_insert_normal_prob(b: &mut Bencher) {
-            let mut gbloom = GrowableBloom::new(0.05, 1000);
+            let mut gbloom = GrowableBloom::new(0.01, 1000);
             b.iter(|| gbloom.insert(10));
         }
         #[bench]
         fn bench_insert_small_prob(b: &mut Bencher) {
-            let mut gbloom = GrowableBloom::new(0.0005, 1000);
+            let mut gbloom = GrowableBloom::new(0.001, 1000);
             b.iter(|| gbloom.insert(10));
         }
         #[bench]
         fn bench_many(b: &mut Bencher) {
-            let mut gbloom = GrowableBloom::new(0.05, 100000);
+            let mut gbloom = GrowableBloom::new(0.01, 100000);
             b.iter(|| gbloom.insert(10));
         }
         #[bench]
         fn bench_insert_medium(b: &mut Bencher) {
             let s: String = (0..100).map(|_| 'X').collect();
-            let mut gbloom = GrowableBloom::new(0.05, 100000);
+            let mut gbloom = GrowableBloom::new(0.01, 100000);
             b.iter(|| gbloom.insert(&s))
         }
         #[bench]
         fn bench_insert_large(b: &mut Bencher) {
             let s: String = (0..10000).map(|_| 'X').collect();
-            let mut gbloom = GrowableBloom::new(0.05, 100000);
+            let mut gbloom = GrowableBloom::new(0.01, 100000);
             b.iter(|| gbloom.insert(&s))
         }
         #[bench]
         fn bench_insert_large_very_small_prob(b: &mut Bencher) {
             let s: String = (0..10000).map(|_| 'X').collect();
-            let mut gbloom = GrowableBloom::new(0.000005, 100000);
+            let mut gbloom = GrowableBloom::new(0.0001, 100000);
             b.iter(|| gbloom.insert(&s))
         }
         #[bench]
         fn bench_grow(b: &mut Bencher) {
-            let mut gbloom = GrowableBloom::new(0.90, 1);
             b.iter(|| {
-                for i in 0..100 {
+                let mut gbloom = GrowableBloom::new(0.01, 100);
+                for i in 0..1000 {
                     gbloom.insert(&i);
                     assert!(gbloom.contains(&i));
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,13 +16,15 @@ use std::{
 #[derive(Deserialize, Serialize, PartialEq, Clone, Debug)]
 struct Bloom {
     /// The actual bit field. Set to 0 with `Bloom::new`.
-    #[serde(with = "serde_bytes")]
+    #[serde(rename = "b", with = "serde_bytes")]
     buffer: Vec<u8>,
     /// The number of slices in the bloom filter.
     /// Equivalent to the hash function in the classic bloom filter.
     /// A single insertion will result in a single bit being set in each slice.
+    #[serde(rename = "k")]
     num_slices: usize,
     /// The _bit_ length of each slice.
+    #[serde(rename = "s")]
     slice_len: usize,
 }
 
@@ -180,12 +182,17 @@ fn double_hashing_hashes<T: Hash>(item: T) -> (usize, usize) {
 #[derive(Deserialize, Serialize, PartialEq, Clone, Debug)]
 pub struct GrowableBloom {
     /// The constituent bloom filters
+    #[serde(rename = "b")]
     blooms: Vec<Bloom>,
+    #[serde(rename = "e")]
     desired_error_prob: f64,
+    #[serde(rename = "t")]
     est_insertions: usize,
     /// Number of items successfully inserted
+    #[serde(rename = "i")]
     inserts: usize,
     /// Item capacity
+    #[serde(rename = "c")]
     capacity: usize,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,8 @@ use std::{
     num::NonZeroU64,
 };
 
+mod stable_hasher;
+
 /// Base Bloom Filter
 #[derive(Deserialize, Serialize, PartialEq, Clone, Debug)]
 struct Bloom {
@@ -168,8 +170,7 @@ impl Bloom {
 /// Return 2 hashes for `item` that can be used as h1 and h2 fordouble hashing.
 /// See https://en.wikipedia.org/wiki/Double_hashing#Enhanced_double_hashing for details.
 fn double_hashing_hashes<T: Hash>(item: T) -> (u64, u64) {
-    // Using xxh3-64 with default seed/secret as a portable hasher.
-    let mut hasher = xxhash_rust::xxh3::Xxh3::new();
+    let mut hasher = stable_hasher::StableHasher::new();
     item.hash(&mut hasher);
     let h1 = hasher.finish();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@ use std::{
 struct Bloom {
     /// The actual bit field. Set to 0 with `Bloom::new`.
     #[serde(rename = "b", with = "serde_bytes")]
-    buffer: Vec<u8>,
+    buffer: Box<[u8]>,
     /// The number of slices in the partitioned bloom filter.
     /// Equivalent to the number of hash function in the classic bloom filter.
     /// An insertion will result in a bit being set in each slice.
@@ -48,7 +48,10 @@ impl Bloom {
 
         let mut buffer = Vec::with_capacity(buffer_bytes);
         buffer.resize(buffer_bytes, 0);
-        Bloom { buffer, num_slices }
+        Bloom {
+            buffer: buffer.into_boxed_slice(),
+            num_slices,
+        }
     }
 
     /// Create an index iterator for a given item.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,6 +165,8 @@ impl Bloom {
     }
 }
 
+/// Return 2 hashes for `item` that can be used as h1 and h2 fordouble hashing.
+/// See https://en.wikipedia.org/wiki/Double_hashing#Enhanced_double_hashing for details.
 fn double_hashing_hashes<T: Hash>(item: T) -> (u64, u64) {
     // Using xxh3-64 with default seed/secret as a portable hasher.
     let mut hasher = xxhash_rust::xxh3::Xxh3::new();

--- a/src/stable_hasher.rs
+++ b/src/stable_hasher.rs
@@ -1,0 +1,99 @@
+use std::hash::Hasher;
+
+/// Wrapper over a hasher that provides stable output across platforms
+/// Based on https://github.com/rust-lang/rust/blob/c0955a34bcb17f0b31d7b86522a520ebe7fa93ac/src/librustc_data_structures/stable_hasher.rs#L78-L166
+///
+/// To that end we always convert integers to little-endian format before
+/// hashing and the architecture dependent `isize` and `usize` types are
+/// extended to 64 bits if needed.
+pub struct StableHasher {
+    /// Using xxh3-64 with default seed/secret as the portable hasher.
+    state: xxhash_rust::xxh3::Xxh3,
+}
+
+impl StableHasher {
+    #[inline]
+    pub fn new() -> Self {
+        Self {
+            state: xxhash_rust::xxh3::Xxh3::new(),
+        }
+    }
+}
+
+impl Hasher for StableHasher {
+    #[inline]
+    fn finish(&self) -> u64 {
+        self.state.finish()
+    }
+
+    #[inline]
+    fn write(&mut self, bytes: &[u8]) {
+        self.state.write(bytes);
+    }
+
+    #[inline]
+    fn write_u8(&mut self, i: u8) {
+        self.state.write_u8(i);
+    }
+
+    #[inline]
+    fn write_u16(&mut self, i: u16) {
+        self.state.write_u16(i.to_le());
+    }
+
+    #[inline]
+    fn write_u32(&mut self, i: u32) {
+        self.state.write_u32(i.to_le());
+    }
+
+    #[inline]
+    fn write_u64(&mut self, i: u64) {
+        self.state.write_u64(i.to_le());
+    }
+
+    #[inline]
+    fn write_u128(&mut self, i: u128) {
+        self.state.write_u128(i.to_le());
+    }
+
+    #[inline]
+    fn write_usize(&mut self, i: usize) {
+        // Always treat usize as u64 so we get the same results on 32 and 64 bit
+        // platforms. This is important for symbol hashes when cross compiling,
+        // for example.
+        self.state.write_u64((i as u64).to_le());
+    }
+
+    #[inline]
+    fn write_i8(&mut self, i: i8) {
+        self.state.write_i8(i);
+    }
+
+    #[inline]
+    fn write_i16(&mut self, i: i16) {
+        self.state.write_i16(i.to_le());
+    }
+
+    #[inline]
+    fn write_i32(&mut self, i: i32) {
+        self.state.write_i32(i.to_le());
+    }
+
+    #[inline]
+    fn write_i64(&mut self, i: i64) {
+        self.state.write_i64(i.to_le());
+    }
+
+    #[inline]
+    fn write_i128(&mut self, i: i128) {
+        self.state.write_i128(i.to_le());
+    }
+
+    #[inline]
+    fn write_isize(&mut self, i: isize) {
+        // Always treat isize as i64 so we get the same results on 32 and 64 bit
+        // platforms. This is important for symbol hashes when cross compiling,
+        // for example.
+        self.state.write_i64((i as i64).to_le());
+    }
+}


### PR DESCRIPTION
Hello, I was using the crate in a project so I spotted and addressed a few shortcomings.

Problem: BitVec Serialization format is sub-optimal, which might not be good when a bloom filter is involved.
Solution: Use a simple Vec<u8> and serialize as bytes.

Problem: Empty filter allocates
Solution: Don't eagerly add a filter on new()

Problem: Grow and error tightening factor wasn't clear. It was sort-of adding 1 slice per growth?
Solution: Use a 2x growth factor and 0.8 tightening factor, which gives a ~5x upper bound on fp ratio even after 1000x growth.

Problem: Arbitrary hashing strategy
Solution: Use enhanced-double-hashing strategy which is both simpler and mathematically correct.

Problem: Bit fill ratio of 0.8 results in a completely off false positive ratio. BFs are built around a 0.5 fill factor. In addition, that's not practical performance wise.
Solution: Use a insert counter to estimate fill factor, which is sort-of the standard for performant implementations.

Not correctness related:
* Switched to ahash hasher, which became the de-facto performance focused hasher in the ecosystem.